### PR TITLE
use ESC-key to end search mode in browse form

### DIFF
--- a/core/nucommon.js
+++ b/core/nucommon.js
@@ -773,6 +773,8 @@ function nuBindCtrlEvents(){
 				$(ae).blur();
 				$(ae).focus();
 				if (nuFormsUnsaved() == 0) nuClosePopup();
+                        } else if (nuFormType() == 'browse') {
+                                nuSearchAction("");
 			}
 
 		}


### PR DESCRIPTION
To exit the search mode in browse form, one should manually click in the search field, delete the search term and press the Enter key.
With the suggested code, one can simply press the escape key.